### PR TITLE
Fix: Sync switch state with system theme

### DIFF
--- a/components/navbar/darkmodeswitch.tsx
+++ b/components/navbar/darkmodeswitch.tsx
@@ -3,10 +3,10 @@ import { useTheme as useNextTheme } from "next-themes";
 import { Switch } from "@nextui-org/react";
 
 export const DarkModeSwitch = () => {
-  const { setTheme, theme } = useNextTheme();
+  const { setTheme, resolvedTheme } = useNextTheme();
   return (
     <Switch
-      isSelected={theme === "dark" ? true : false}
+      isSelected={resolvedTheme === "dark" ? true : false}
       onValueChange={(e) => setTheme(e ? "dark" : "light")}
     />
   );


### PR DESCRIPTION
Refines DarkModeSwitch to accurately reflect system's theme by replacing 'theme' with 'resolvedTheme' from next-themes.
This eliminates the need for double-switching when transitioning from a dark system theme to light theme.