### PR TITLE
Fix sidebar overlay with Modal

### DIFF
--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -25,7 +25,7 @@ export const SidebarWrapper = () => {
   const { collapsed, setCollapsed } = useSidebarContext();
 
   return (
-    <aside className="h-screen z-[202] sticky top-0">
+    <aside className="h-screen z-[20] sticky top-0">
       {collapsed ? (
         <div className={Sidebar.Overlay()} onClick={setCollapsed} />
       ) : null}


### PR DESCRIPTION
**Resolve the issue of the sidebar overlaying the Modal by setting the sidebar's z-index to 20.**


Before: 
![502d064ded514135a06fcbd4c79aa97](https://github.com/Siumauricio/nextui-dashboard-template/assets/146353430/afffcc1d-66b6-4ddd-b695-d97dccc76abb)
After:
![58bb7ac1a38ca1a82e18fa05bc69363](https://github.com/Siumauricio/nextui-dashboard-template/assets/146353430/241dc967-c525-45a3-9f00-832656e9d4b6)
