### PR TITLE
add over flow hidden for the card body

### DIFF
--- a/components/home/card-balance1.tsx
+++ b/components/home/card-balance1.tsx
@@ -5,7 +5,7 @@ import { Community } from "../icons/community";
 export const CardBalance1 = () => {
   return (
     <Card className="xl:max-w-sm bg-primary rounded-xl shadow-md px-3 w-full">
-      <CardBody className="py-5">
+      <CardBody className="py-5 overflow-hidden">
         <div className="flex gap-2.5">
           <Community />
           <div className="flex flex-col">


### PR DESCRIPTION
In the chrome browser card showing the scroller so made the overflow hidden.

![image](https://github.com/Siumauricio/nextui-dashboard-template/assets/78607953/183546d4-65ca-4ae4-bf50-3a877973a687)
