### PR TITLE
fix: dropdown icon of sidebar

### DIFF
--- a/components/icons/sidebar/chevron-down-icon.tsx
+++ b/components/icons/sidebar/chevron-down-icon.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface Props extends React.SVGAttributes<SVGElement> {}
+export const ChevronDownIcon = ({ ...props }: Props) => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            {...props}>
+            <path
+                className="fill-default-400"
+                d="m6.293 10.707 1.414-1.414L12 13.586l4.293-4.293 1.414 1.414L12 16.414z"></path>
+        </svg>
+    );
+};

--- a/components/sidebar/collapse-items.tsx
+++ b/components/sidebar/collapse-items.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import { ChevronUpIcon } from "../icons/sidebar/chevron-up-icon";
+import { ChevronDownIcon } from "../icons/sidebar/chevron-down-icon";
 import { Accordion, AccordionItem } from "@nextui-org/react";
 import clsx from "clsx";
 
@@ -17,7 +17,7 @@ export const CollapseItems = ({ icon, items, title }: Props) => {
     <div className="flex gap-4 h-full items-center cursor-pointer">
       <Accordion className="px-0">
         <AccordionItem
-          indicator={<ChevronUpIcon />}
+          indicator={<ChevronDownIcon />}
           classNames={{
             indicator: "data-[open=true]:-rotate-180",
             trigger:


### PR DESCRIPTION
**Fix the direction of the dropdown icon in the 'Balances' menu of the sidebar.**

This commit fixes the direction of the dropdown icon. Previously, it was pointing upward. To correct this, I created a new file with a downward-pointing SVG following the same filename format and replaced the icon Component with the new one.

Screenshot: 
![image](https://github.com/user-attachments/assets/cecf57f0-6483-4d5c-821f-06d982a8df8c)
