### PR TITLE
fix: overlap between the sidebar and the navigation bar on mobile view

### DIFF
--- a/components/sidebar/sidebar.styles.ts
+++ b/components/sidebar/sidebar.styles.ts
@@ -5,7 +5,7 @@ export const SidebarWrapper = tv({
 
   variants: {
     collapsed: {
-      true: "translate-x-0 ml-0 [display:inherit]",
+      true: "translate-x-0 ml-0 pt-20 [display:inherit]",
     },
   },
   // ""


### PR DESCRIPTION
Fix the overlap between the sidebar and the navigation bar on mobile devices.

Before:
![0b017f22a8b49cd2467098de0c0ee78](https://github.com/user-attachments/assets/f944d2e8-e8ac-4aa2-8fb2-e87024030693)

After:
![71eecad509f1356096a51399f660f08](https://github.com/user-attachments/assets/c2cc01e9-1492-410b-9e06-4a224588eb74)