### PR TITLE
fix padding and top margin in accounts section for mobile screen

### DIFF
--- a/components/accounts/index.tsx
+++ b/components/accounts/index.tsx
@@ -14,7 +14,7 @@ import { AddUser } from "./add-user";
 
 export const Accounts = () => {
   return (
-    <div className="my-14 lg:px-6 max-w-[95rem] mx-auto w-full flex flex-col gap-4">
+    <div className="my-10 px-4 lg:px-6 max-w-[95rem] mx-auto w-full flex flex-col gap-4">
       <ul className="flex">
         <li className="flex gap-2">
           <HouseIcon />


### PR DESCRIPTION
**### Before -** 
[
![before](https://github.com/user-attachments/assets/fc2ba745-c95c-4bfd-a379-1f1e7f2cfa41)
](url)


**### After -** 
![after](https://github.com/user-attachments/assets/9eecd483-cd5f-48dc-bab4-6643b1adde56)
